### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.45-stretch as base
+FROM rust:1.71-slim as base
 
 WORKDIR /representer
 


### PR DESCRIPTION
the error:
https://github.com/exercism/rust-representer/actions/runs/5678569236/job/15389057649

looks like debian strech is not supported anymore. updating to a recent base image fixed it for me locally.